### PR TITLE
Support functions, but without tail recursion

### DIFF
--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -89,6 +89,16 @@ test('Test assignment', async () => {
   await testNonDeterministicCode('let a = amb(1, 2); a = amb(4, 5); a;', [4, 5, 4, 5])
 })
 
+test('Test functions with non deterministic terms', async () => {
+  await testNonDeterministicCode(
+    `function foo() {
+      return amb(true, false) ? 'a string' : amb(10, 20);
+     }
+     foo();`,
+    ['a string', 10, 20]
+  )
+})
+
 // ---------------------------------- Helper functions  -------------------------------------------
 
 const nonDetTestOptions = {

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -11,11 +11,27 @@ test('Empty code returns undefined', async () => {
 test('Deterministic calculation', async () => {
   await testDeterministicCode('1 + 4 - 10 * 5;', -45)
 })
+
+test('Test builtin list functions', async () => {
+  await testDeterministicCode('pair(false, 10);', [false, 10])
+  await testDeterministicCode('list();', null)
+  await testDeterministicCode('list(1);', [1, null])
+  await testDeterministicCode('head(list(1));', 1)
+  await testDeterministicCode('tail(list(1));', null)
+  await testDeterministicCode(
+    `function increment(x) {
+      x + 1;
+    }
+    map(increment, list(1,2,3));`,
+    [2,[3,[4, null]]]
+  )
+})
 // ---------------------------------- Non deterministic code tests -------------------------------
 
 test('Test simple amb application', async () => {
   await testNonDeterministicCode('amb(1, 4 + 5, 3 - 10);', [1, 9, -7])
 })
+
 
 // ---------------------------------- Helper functions  -------------------------------------------
 
@@ -35,14 +51,14 @@ async function testNonDeterministicCode(code: string, expectedValues: any[]) {
   let result: Result = await runInContext(code, context, nonDetTestOptions)
   const numOfRuns = expectedValues.length
   for (let i = 0; i < numOfRuns; i++) {
-    expect((result as SuspendedNonDet).value).toBe(expectedValues[i])
-    expect(result.status).toBe('suspended-non-det')
+    expect((result as SuspendedNonDet).value).toEqual(expectedValues[i])
+    expect(result.status).toEqual('suspended-non-det')
     result = await resume(result)
   }
 
   // all non deterministic programs have a final result whose value is undefined
-  expect(result.status).toBe('finished')
-  expect((result as Finished).value).toBe(undefined)
+  expect(result.status).toEqual('finished')
+  expect((result as Finished).value).toEqual(undefined)
 }
 
 function makeNonDetContext() {

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -25,10 +25,11 @@ test('Test builtin list functions', async () => {
     map(increment, list(1,2,3));`,
     [2,[3,[4, null]]]
   )
-
-  test('Deterministic assignment', async () => {
-  await testDeterministicCode('let a = 5; a = 10; a;', 10)
 })
+
+ test('Deterministic assignment', async () => {
+    await testDeterministicCode('let a = 5; a = 10; a;', 10)
+ })
 // ---------------------------------- Non deterministic code tests -------------------------------
 
 test('Test simple amb application', async () => {

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -12,24 +12,52 @@ test('Deterministic calculation', async () => {
   await testDeterministicCode('1 + 4 - 10 * 5;', -45)
 })
 
+test('Deterministic function applications', async () => {
+  await testDeterministicCode(
+    `function factorial(n) {
+      return n === 0 ? 1 : n * factorial(n - 1);
+     }
+     factorial(5);
+    `,
+    120
+  )
+
+  await testDeterministicCode(
+    `function noReturnStatement_returnsUndefined() {
+       20 + 40 - 6;
+       5 - 5;
+       list();
+       reverse(list(1));
+     }`,
+    undefined
+  )
+})
+
 test('Test builtin list functions', async () => {
   await testDeterministicCode('pair(false, 10);', [false, 10])
   await testDeterministicCode('list();', null)
   await testDeterministicCode('list(1);', [1, null])
   await testDeterministicCode('head(list(1));', 1)
   await testDeterministicCode('tail(list(1));', null)
-  await testDeterministicCode(
-    `function increment(x) {
-      x + 1;
-    }
-    map(increment, list(1,2,3));`,
-    [2,[3,[4, null]]]
-  )
 })
 
- test('Deterministic assignment', async () => {
-    await testDeterministicCode('let a = 5; a = 10; a;', 10)
- })
+test('Test prelude list functions', async () => {
+  await testDeterministicCode('is_null(null);', true)
+  await testDeterministicCode('is_null(list(null));', false)
+  await testDeterministicCode(
+    `function increment(n) { return n + 1; }
+     map(increment, list(100, 101, 200));
+    `,
+    [101, [102, [201, null]]]
+  )
+  await testDeterministicCode('append(list(5), list(6,20));', [5, [6, [20, null]]])
+  await testDeterministicCode('append(list(4,5), list());', [4, [5, null]])
+  await testDeterministicCode('reverse(list("hello", true, 0));', [0, [true, ['hello', null]]])
+})
+
+test('Deterministic assignment', async () => {
+  await testDeterministicCode('let a = 5; a = 10; a;', 10)
+})
 // ---------------------------------- Non deterministic code tests -------------------------------
 
 test('Test simple amb application', async () => {

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -187,7 +187,8 @@ const checkNumberOfArguments = (
 }
 
 function* getArgs(context: Context, call: es.CallExpression) {
-  yield* cartesianProduct(context, call.arguments as es.Expression[], [])
+  const args = cloneDeep(call.arguments)
+  return yield* cartesianProduct(context, args as es.Expression[], [])
 }
 
 /* Given a list of non deterministic nodes, this generator returns every
@@ -204,9 +205,9 @@ function* cartesianProduct(
     const nodeValueGenerator = evaluate(currentNode, context)
     let nodeValue = nodeValueGenerator.next()
     while (!nodeValue.done) {
-      nodeValues.unshift(nodeValue.value)
+      nodeValues.push(nodeValue.value)
       yield* cartesianProduct(context, nodes, nodeValues)
-      nodeValues.shift()
+      nodeValues.pop()
       nodeValue = nodeValueGenerator.next()
     }
     nodes.unshift(currentNode)

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -601,7 +601,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
       yield new ReturnValue(returnValue.value)
       returnValue = returnValueGenerator.next()
     }
-  
+
   },
 
   WhileStatement: function*(node: es.WhileStatement, context: Context) {
@@ -687,13 +687,10 @@ export function* apply(
       context,
       cloneDeep(fun.node.body) as es.BlockStatement
     )
-    let applicationValue = applicationValueGenerator.next()
-
-    while (!applicationValue.done) {
+    for (const applicationValue of applicationValueGenerator) {
       popEnvironment(context)
-      yield unwrapReturnValue(applicationValue.value, undefined)
+      yield unwrapReturnValue(applicationValue, undefined)
       pushEnvironment(context, environment)
-      applicationValue = applicationValueGenerator.next()
     }
   } else if (typeof fun === 'function') {
     try {

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -351,7 +351,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   },
 
   FunctionExpression: function*(node: es.FunctionExpression, context: Context) {
-    return new Closure(node, currentEnvironment(context), context)
+    yield new Closure(node, currentEnvironment(context), context)
   },
 
   ArrowFunctionExpression: function*(node: es.ArrowFunctionExpression, context: Context) {

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -331,24 +331,24 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   },
 
   CallExpression: function*(node: es.CallExpression, context: Context) {
-    const callee = node.callee as es.Identifier;
-    if (callee.name === 'amb') {
-      yield* getAmbArgs(context, node)
+    const callee = node.callee;
+    if (rttc.isIdentifier(callee)) {
+      if (callee.name === 'amb') {
+        return yield* getAmbArgs(context, node)
+      } else if (callee.name === 'require') {
+        return yield* evaluateRequire(context, node)
+      }
     }
 
-    if (callee.name === 'require') {
-      yield* evaluateRequire(context, node)
+    const calleeGenerator = evaluate(node.callee, context)
+    const calleeValue = calleeGenerator.next()
+    while (!calleeValue.done) {
+      const argsGenerator = getArgs(context, node)
+      const args = undefined;
+      const thisContext = undefined;
+      const result = yield* apply(context, callee, args, node, thisContext)
+      return result
     }
-
-    /*
-    const callee = yield* evaluate(node.callee, context)
-    const args = yield* getArgs(context, node)
-    let thisContext
-    if (node.callee.type === 'MemberExpression') {
-      thisContext = yield* evaluate(node.callee.object, context)
-    }
-    const result = yield* apply(context, callee, args, node, thisContext)
-    return result */
   },
 
   NewExpression: function*(node: es.NewExpression, context: Context) {

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -4,7 +4,7 @@ import * as constants from '../constants'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { Context, Environment, Frame, Value } from '../types'
-import { conditionalExpression, literal, primitive } from '../utils/astCreator'
+import { primitive } from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
 import Closure from './closure'
@@ -125,8 +125,6 @@ function defineVariable(context: Context, name: string, value: Value, constant =
 }
 
 const currentEnvironment = (context: Context) => context.runtime.environments[0]
-const replaceEnvironment = (context: Context, environment: Environment) =>
-  (context.runtime.environments[0] = environment)
 const popEnvironment = (context: Context) => context.runtime.environments.shift()
 const pushEnvironment = (context: Context, environment: Environment) =>
   context.runtime.environments.unshift(environment)
@@ -189,11 +187,30 @@ const checkNumberOfArguments = (
 }
 
 function* getArgs(context: Context, call: es.CallExpression) {
-  const args = []
-  for (const arg of call.arguments) {
-    args.push(yield* evaluate(arg, context))
+  yield* cartesianProduct(context, call.arguments as es.Expression[], [])
+}
+
+/* Given a list of non deterministic nodes, this generator returns every
+ * combination of values of these nodes */
+function* cartesianProduct(
+  context: Context,
+  nodes: es.Expression[],
+  nodeValues: Value[]
+): IterableIterator<Value[]> {
+  if (nodes.length === 0) {
+    yield nodeValues
+  } else {
+    const currentNode = nodes.shift()! // we need the postfix ! to tell compiler that nodes array is nonempty
+    const nodeValueGenerator = evaluate(currentNode, context)
+    let nodeValue = nodeValueGenerator.next()
+    while (!nodeValue.done) {
+      nodeValues.unshift(nodeValue.value)
+      yield* cartesianProduct(context, nodes, nodeValues)
+      nodeValues.shift()
+      nodeValue = nodeValueGenerator.next()
+    }
+    nodes.unshift(currentNode)
   }
-  return args
 }
 
 function* getAmbArgs(context: Context, call: es.CallExpression) {
@@ -204,13 +221,14 @@ function* getAmbArgs(context: Context, call: es.CallExpression) {
   }
 }
 
+/*
 function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalExpression {
   if (node.operator === '&&') {
     return conditionalExpression(node.left, node.right, literal(false), node.loc!)
   } else {
     return conditionalExpression(node.left, literal(true), node.right, node.loc!)
   }
-}
+} */
 
 function* evaluateRequire(context: Context, call: es.CallExpression) {
   // TODO: Throw an error if require does not have 0 arguments
@@ -318,7 +336,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   },
 
   ArrowFunctionExpression: function*(node: es.ArrowFunctionExpression, context: Context) {
-    return Closure.makeFromArrowFunction(node, currentEnvironment(context), context)
+    yield Closure.makeFromArrowFunction(node, currentEnvironment(context), context)
   },
 
   Identifier: function*(node: es.Identifier, context: Context) {
@@ -341,13 +359,17 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     }
 
     const calleeGenerator = evaluate(node.callee, context)
-    const calleeValue = calleeGenerator.next()
+    let calleeValue = calleeGenerator.next()
     while (!calleeValue.done) {
       const argsGenerator = getArgs(context, node)
-      const args = undefined;
+      let args = argsGenerator.next()
       const thisContext = undefined;
-      const result = yield* apply(context, callee, args, node, thisContext)
-      return result
+
+      while(!args.done) {
+        yield* apply(context, calleeValue.value, args.value, node, thisContext)
+        args = argsGenerator.next();
+      }
+      calleeValue = calleeGenerator.next();
     }
   },
 
@@ -548,7 +570,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     // tslint:disable-next-line:no-any
     const closure = new Closure(node, currentEnvironment(context), context)
     defineVariable(context, id.name, closure, true)
-    return undefined
+    yield undefined
   },
 
   IfStatement: function*(node: es.IfStatement | es.ConditionalExpression, context: Context) {
@@ -559,6 +581,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return yield* evaluate(node.expression, context)
   },
 
+  /*
   ReturnStatement: function*(node: es.ReturnStatement, context: Context) {
     let returnExpression = node.argument!
 
@@ -581,7 +604,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     } else {
       return new ReturnValue(yield* evaluate(returnExpression, context))
     }
-  },
+  }, */
 
   WhileStatement: function*(node: es.WhileStatement, context: Context) {
     let value: any // tslint:disable-line
@@ -646,61 +669,36 @@ export function* apply(
   node: es.CallExpression,
   thisContext?: Value
 ) {
-  let result: Value
-  let total = 0
+  if (fun instanceof Closure) {
+    checkNumberOfArguments(context, fun, args, node!)
+    const environment = createEnvironment(fun, args, node)
+    environment.thisContext = thisContext
+    pushEnvironment(context, environment)
+    yield* evaluateBlockSatement(context, fun.node.body as es.BlockStatement)
+  } else if (typeof fun === 'function') {
+    try {
+      yield fun.apply(thisContext, args)
+    } catch (e) {
+      // Recover from exception
+      context.runtime.environments = context.runtime.environments.slice(
+        -context.numberOfOuterEnvironments
+      )
 
-  while (!(result instanceof ReturnValue)) {
-    if (fun instanceof Closure) {
-      checkNumberOfArguments(context, fun, args, node!)
-      const environment = createEnvironment(fun, args, node)
-      environment.thisContext = thisContext
-      if (result instanceof TailCallReturnValue) {
-        replaceEnvironment(context, environment)
-      } else {
-        pushEnvironment(context, environment)
-        total++
+      const loc = node ? node.loc! : constants.UNKNOWN_LOCATION
+      if (!(e instanceof RuntimeSourceError || e instanceof errors.ExceptionError)) {
+        // The error could've arisen when the builtin called a source function which errored.
+        // If the cause was a source error, we don't want to include the error.
+        // However if the error came from the builtin itself, we need to handle it.
+        return handleRuntimeError(context, new errors.ExceptionError(e, loc))
       }
-      result = yield* evaluateBlockSatement(context, fun.node.body as es.BlockStatement)
-      if (result instanceof TailCallReturnValue) {
-        fun = result.callee
-        node = result.node
-        args = result.args
-      } else if (!(result instanceof ReturnValue)) {
-        // No Return Value, set it as undefined
-        result = new ReturnValue(undefined)
-      }
-    } else if (typeof fun === 'function') {
-      try {
-        result = fun.apply(thisContext, args)
-        break
-      } catch (e) {
-        // Recover from exception
-        context.runtime.environments = context.runtime.environments.slice(
-          -context.numberOfOuterEnvironments
-        )
-
-        const loc = node ? node.loc! : constants.UNKNOWN_LOCATION
-        if (!(e instanceof RuntimeSourceError || e instanceof errors.ExceptionError)) {
-          // The error could've arisen when the builtin called a source function which errored.
-          // If the cause was a source error, we don't want to include the error.
-          // However if the error came from the builtin itself, we need to handle it.
-          return handleRuntimeError(context, new errors.ExceptionError(e, loc))
-        }
-        result = undefined
-        throw e
-      }
-    } else {
-      return handleRuntimeError(context, new errors.CallingNonFunctionValue(fun, node))
+      throw e
     }
+  } else {
+    return handleRuntimeError(context, new errors.CallingNonFunctionValue(fun, node))
   }
-  // Unwraps return value and release stack environment
-  if (result instanceof ReturnValue) {
-    result = result.value
-  }
-  for (let i = 1; i <= total; i++) {
-    popEnvironment(context)
-  }
-  return result
+
+  popEnvironment(context)
+  return
 }
 
 export { evaluate as nonDetEvaluate }

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -222,14 +222,13 @@ function* getAmbArgs(context: Context, call: es.CallExpression) {
   }
 }
 
-/*
 function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalExpression {
   if (node.operator === '&&') {
     return conditionalExpression(node.left, node.right, literal(false), node.loc!)
   } else {
     return conditionalExpression(node.left, literal(true), node.right, node.loc!)
   }
-} */
+}
 
 function* evaluateRequire(context: Context, call: es.CallExpression) {
   if (call.arguments.length !== 1) {
@@ -265,14 +264,6 @@ function* reduceIf(
     yield test.value ? node.consequent : node.alternate!
 
     test = testGenerator.next()
-  }
-}
-
-function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalExpression {
-  if (node.operator === '&&') {
-    return conditionalExpression(node.left, node.right, literal(false), node.loc!)
-  } else {
-    return conditionalExpression(node.left, literal(true), node.right, node.loc!)
   }
 }
 

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -675,7 +675,7 @@ export function* apply(
     const environment = createEnvironment(fun, args, node)
     environment.thisContext = thisContext
     pushEnvironment(context, environment)
-    yield* evaluateBlockSatement(context, fun.node.body as es.BlockStatement)
+    yield* evaluateBlockSatement(context, cloneDeep(fun.node.body) as es.BlockStatement)
   } else if (typeof fun === 'function') {
     try {
       yield fun.apply(thisContext, args)

--- a/src/utils/rttc.ts
+++ b/src/utils/rttc.ts
@@ -108,3 +108,7 @@ export const checkMemberAccess = (node: es.Node, obj: Value, prop: Value) => {
     return new TypeError(node, '', 'object or array', typeOf(obj))
   }
 }
+
+export const isIdentifier = (node: any): node is es.Identifier => {
+  return (node as es.Identifier).name !== undefined
+}


### PR DESCRIPTION
With this PR:
- We can declare functions, but tail recursive calls are not optimised
- We can apply functions that we've declared OR the built in functions


Try in the REPL:
`list(amb(1,2,3));`

`function integer_from(n) { amb(n, integer_from(n + 1)); } integer_from(1);`

```
function an_element_of(xs) { require(!is_null(xs)); amb(head(xs), an_element_of(tail(xs))); } an_element_of(list(1,2,3));
```


