### PR TITLE
Support logical expressions

### DIFF
--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -33,6 +33,22 @@ test('Deterministic function applications', async () => {
   )
 })
 
+test('Deterministic logical expressions', async () => {
+  await testDeterministicCode(`true && (false || true) && (true && false);`, false)
+
+  await testDeterministicCode(
+    `function foo() { return foo(); }\
+      true || foo();`,
+    true
+  )
+
+  await testDeterministicCode(
+    `function foo() { return foo(); }\
+    false && foo();`,
+    false
+  )
+})
+
 test('Test builtin list functions', async () => {
   await testDeterministicCode('pair(false, 10);', [false, 10])
   await testDeterministicCode('list();', null)
@@ -96,6 +112,14 @@ test('Test functions with non deterministic terms', async () => {
      }
      foo();`,
     ['a string', 10, 20]
+  )
+})
+
+test('Test binary expressions', async () => {
+  await testNonDeterministicCode(
+    `amb(true, false) && amb(false, true) || amb(false);
+    `,
+    [false, true, false]
   )
 })
 

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -456,7 +456,8 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   },
 
   LogicalExpression: function*(node: es.LogicalExpression, context: Context) {
-    yield* evaluateConditional(transformLogicalExpression(node), context)
+    const conditional: es.ConditionalExpression = transformLogicalExpression(node)
+    yield* evaluateConditional(conditional, context)
   },
 
   VariableDeclaration: function*(node: es.VariableDeclaration, context: Context) {

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -4,7 +4,7 @@ import * as constants from '../constants'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { Context, Environment, Frame, Value } from '../types'
-import { primitive } from '../utils/astCreator'
+import { primitive, conditionalExpression, literal } from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
 import Closure from './closure'
@@ -221,14 +221,14 @@ function* getAmbArgs(context: Context, call: es.CallExpression) {
     assignIn(context, cloneDeep(originalContext)) // reset context
   }
 }
-/*
+
 function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalExpression {
   if (node.operator === '&&') {
     return conditionalExpression(node.left, node.right, literal(false), node.loc!)
   } else {
     return conditionalExpression(node.left, literal(true), node.right, node.loc!)
   }
-}*/
+}
 
 function* evaluateRequire(context: Context, call: es.CallExpression) {
   if (call.arguments.length !== 1) {
@@ -453,6 +453,10 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
 
   ConditionalExpression: function*(node: es.ConditionalExpression, context: Context) {
     yield* evaluateConditional(node, context)
+  },
+
+  LogicalExpression: function*(node: es.LogicalExpression, context: Context) {
+    yield* evaluateConditional(transformLogicalExpression(node), context)
   },
 
   VariableDeclaration: function*(node: es.VariableDeclaration, context: Context) {


### PR DESCRIPTION
Adds support for binary operations: ` && | ||`

Resolves #13 
Depends on #3 
