### PR TITLE
Add support for non-deterministic language

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "astring": "^1.3.1",
     "node-getopt": "^0.3.2",
     "source-map": "^0.7.3",
-    "jest-html-reporter": "^2.8.2"
+    "jest-html-reporter": "^2.8.2",
+    "@types/lodash.assignin": "^4.2.6",
+    "@types/lodash.clonedeep": "^4.5.6"
   },
   "main": "dist/index",
   "types": "dist/index",

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -1,0 +1,53 @@
+/* tslint:disable:max-line-length */
+import { runInContext, resume, IOptions } from '../index'
+import { mockContext } from '../mocks/context'
+import { SuspendedNonDet, Finished } from '../types'
+
+const nonDetTestOptions = {
+  scheduler: 'preemptive',
+  executionMethod: 'non-det-interpreter'
+} as Partial<IOptions>
+
+// ---------------------------------- Deterministic code tests --------------------------------
+test('Empty code returns undefined', async () => {
+  await testDeterministicCode('', undefined)
+})
+
+test('Deterministic calculation', async () => {
+  await testDeterministicCode('1 + 4 - 10 * 5;', -45)
+})
+
+async function testDeterministicCode(code: string, expectedValue: any) {
+  const context = makeNonDetContext()
+  let result = await runInContext(code, context, nonDetTestOptions)
+  expect((result as SuspendedNonDet).value).toBe(expectedValue)
+  expect(result.status).toBe('suspended-non-det')
+  // deterministic code only has a single value
+  result = await resume(result)
+  expect(result.status).toBe('finished')
+  expect((result as Finished).value).toBe(undefined)
+}
+// ---------------------------------- Non deterministic code tests -------------------------------
+
+test('Test simple amb application', async () => {
+  const context = makeNonDetContext()
+  let result = await runInContext('amb(1, 4 + 5, 3 - 10);', context, nonDetTestOptions)
+  expect(result.status).toBe('suspended-non-det')
+  expect((result as SuspendedNonDet).value).toBe(1)
+  result = await resume(result)
+  expect(result.status).toBe('suspended-non-det')
+  expect((result as SuspendedNonDet).value).toBe(9)
+  result = await resume(result)
+  expect(result.status).toBe('suspended-non-det')
+  expect((result as SuspendedNonDet).value).toBe(-7)
+
+  result = await resume(result)
+  expect(result.status).toBe('finished')
+  expect((result as Finished).value).toBe(undefined)
+})
+
+function makeNonDetContext() {
+  const context = mockContext(4)
+  context.executionMethod = 'non-det-interpreter'
+  return context
+}

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -1,12 +1,7 @@
 /* tslint:disable:max-line-length */
-import { runInContext, resume, IOptions } from '../index'
+import { runInContext, resume, IOptions, Result } from '../index'
 import { mockContext } from '../mocks/context'
 import { SuspendedNonDet, Finished } from '../types'
-
-const nonDetTestOptions = {
-  scheduler: 'preemptive',
-  executionMethod: 'non-det-interpreter'
-} as Partial<IOptions>
 
 // ---------------------------------- Deterministic code tests --------------------------------
 test('Empty code returns undefined', async () => {
@@ -16,35 +11,39 @@ test('Empty code returns undefined', async () => {
 test('Deterministic calculation', async () => {
   await testDeterministicCode('1 + 4 - 10 * 5;', -45)
 })
-
-async function testDeterministicCode(code: string, expectedValue: any) {
-  const context = makeNonDetContext()
-  let result = await runInContext(code, context, nonDetTestOptions)
-  expect((result as SuspendedNonDet).value).toBe(expectedValue)
-  expect(result.status).toBe('suspended-non-det')
-  // deterministic code only has a single value
-  result = await resume(result)
-  expect(result.status).toBe('finished')
-  expect((result as Finished).value).toBe(undefined)
-}
 // ---------------------------------- Non deterministic code tests -------------------------------
 
 test('Test simple amb application', async () => {
-  const context = makeNonDetContext()
-  let result = await runInContext('amb(1, 4 + 5, 3 - 10);', context, nonDetTestOptions)
-  expect(result.status).toBe('suspended-non-det')
-  expect((result as SuspendedNonDet).value).toBe(1)
-  result = await resume(result)
-  expect(result.status).toBe('suspended-non-det')
-  expect((result as SuspendedNonDet).value).toBe(9)
-  result = await resume(result)
-  expect(result.status).toBe('suspended-non-det')
-  expect((result as SuspendedNonDet).value).toBe(-7)
+  await testNonDeterministicCode('amb(1, 4 + 5, 3 - 10);', [1, 9, -7])
+})
 
-  result = await resume(result)
+// ---------------------------------- Helper functions  -------------------------------------------
+
+const nonDetTestOptions = {
+  scheduler: 'preemptive',
+  executionMethod: 'non-det-interpreter'
+} as Partial<IOptions>
+
+async function testDeterministicCode(code: string, expectedValue: any) {
+  /* a deterministic program is equivalent to a non deterministic program
+     that returns a single value */
+  testNonDeterministicCode(code, [expectedValue])
+}
+
+async function testNonDeterministicCode(code: string, expectedValues: any[]) {
+  const context = makeNonDetContext()
+  let result: Result = await runInContext(code, context, nonDetTestOptions)
+  const numOfRuns = expectedValues.length
+  for (let i = 0; i < numOfRuns; i++) {
+    expect((result as SuspendedNonDet).value).toBe(expectedValues[i])
+    expect(result.status).toBe('suspended-non-det')
+    result = await resume(result)
+  }
+
+  // all non deterministic programs have a final result whose value is undefined
   expect(result.status).toBe('finished')
   expect((result as Finished).value).toBe(undefined)
-})
+}
 
 function makeNonDetContext() {
   const context = mockContext(4)

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -17,6 +17,27 @@ test('Test simple amb application', async () => {
   await testNonDeterministicCode('amb(1, 4 + 5, 3 - 10);', [1, 9, -7])
 })
 
+test('Test if-else and conditional expressions', async () => {
+  await testNonDeterministicCode('amb(false, true) ? 4 - 10 : 6;', [6, -6])
+  await testNonDeterministicCode(
+    `if (amb(true, false)) {
+      -100;
+     } else {
+      200 / 2;
+      210;
+     }`,
+    [-100, 210]
+  )
+  await testNonDeterministicCode(
+    `if (amb(100 * 2 === 2, 40 % 2 === 0)) {
+      amb(false, 'test' === 'test') ? amb(false === false, false) ? "hello" : false : amb(5, "world");
+    } else {
+      9 * 10 / 5;
+    }`,
+    [18, 5, 'world', 'hello', false]
+  )
+})
+
 // ---------------------------------- Helper functions  -------------------------------------------
 
 const nonDetTestOptions = {

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -11,6 +11,10 @@ test('Empty code returns undefined', async () => {
 test('Deterministic calculation', async () => {
   await testDeterministicCode('1 + 4 - 10 * 5;', -45)
 })
+
+test('Deterministic assignment', async () => {
+  await testDeterministicCode('let a = 5; a = 10; a;', 10)
+})
 // ---------------------------------- Non deterministic code tests -------------------------------
 
 test('Test simple amb application', async () => {
@@ -38,6 +42,10 @@ test('Test if-else and conditional expressions', async () => {
   )
 })
 
+test('Test assignment', async () => {
+  await testNonDeterministicCode('let a = amb(1, 2); a = amb(4, 5); a;', [4, 5, 4, 5])
+})
+
 // ---------------------------------- Helper functions  -------------------------------------------
 
 const nonDetTestOptions = {
@@ -48,7 +56,7 @@ const nonDetTestOptions = {
 async function testDeterministicCode(code: string, expectedValue: any) {
   /* a deterministic program is equivalent to a non deterministic program
      that returns a single value */
-  testNonDeterministicCode(code, [expectedValue])
+  await testNonDeterministicCode(code, [expectedValue])
 }
 
 async function testNonDeterministicCode(code: string, expectedValues: any[]) {

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -41,8 +41,8 @@ test('Test if-else and conditional expressions', async () => {
 // ---------------------------------- Helper functions  -------------------------------------------
 
 const nonDetTestOptions = {
-  scheduler: 'preemptive',
-  executionMethod: 'non-det-interpreter'
+  scheduler: 'non-det',
+  executionMethod: 'interpreter'
 } as Partial<IOptions>
 
 async function testDeterministicCode(code: string, expectedValue: any) {
@@ -68,6 +68,6 @@ async function testNonDeterministicCode(code: string, expectedValues: any[]) {
 
 function makeNonDetContext() {
   const context = mockContext(4)
-  context.executionMethod = 'non-det-interpreter'
+  context.executionMethod = 'interpreter'
   return context
 }

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -33,6 +33,22 @@ test('Deterministic function applications', async () => {
   )
 })
 
+test('Deterministic logical expressions', async () => {
+  await testDeterministicCode(`true && (false || true) && (true && false);`, false)
+
+  await testDeterministicCode(
+    `function foo() { return foo(); }\
+      true || foo();`,
+    true
+  )
+
+  await testDeterministicCode(
+    `function foo() { return foo(); }\
+    false && foo();`,
+    false
+  )
+})
+
 test('Test builtin list functions', async () => {
   await testDeterministicCode('pair(false, 10);', [false, 10])
   await testDeterministicCode('list();', null)
@@ -96,6 +112,14 @@ test('Test functions with non deterministic terms', async () => {
      }
      foo();`,
     ['a string', 10, 20]
+  )
+})
+
+test('Test binary expressions', async () => {
+  await testNonDeterministicCode(
+    `amb(true, false) && amb(false, true) || amb(false);
+    `,
+    [false, true, false]
   )
 })
 

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -12,6 +12,49 @@ test('Deterministic calculation', async () => {
   await testDeterministicCode('1 + 4 - 10 * 5;', -45)
 })
 
+test('Deterministic function applications', async () => {
+  await testDeterministicCode(
+    `function factorial(n) {
+      return n === 0 ? 1 : n * factorial(n - 1);
+     }
+     factorial(5);
+    `,
+    120
+  )
+
+  await testDeterministicCode(
+    `function noReturnStatement_returnsUndefined() {
+       20 + 40 - 6;
+       5 - 5;
+       list();
+       reverse(list(1));
+     }`,
+    undefined
+  )
+})
+
+test('Test builtin list functions', async () => {
+  await testDeterministicCode('pair(false, 10);', [false, 10])
+  await testDeterministicCode('list();', null)
+  await testDeterministicCode('list(1);', [1, null])
+  await testDeterministicCode('head(list(1));', 1)
+  await testDeterministicCode('tail(list(1));', null)
+})
+
+test('Test prelude list functions', async () => {
+  await testDeterministicCode('is_null(null);', true)
+  await testDeterministicCode('is_null(list(null));', false)
+  await testDeterministicCode(
+    `function increment(n) { return n + 1; }
+     map(increment, list(100, 101, 200));
+    `,
+    [101, [102, [201, null]]]
+  )
+  await testDeterministicCode('append(list(5), list(6,20));', [5, [6, [20, null]]])
+  await testDeterministicCode('append(list(4,5), list());', [4, [5, null]])
+  await testDeterministicCode('reverse(list("hello", true, 0));', [0, [true, ['hello', null]]])
+})
+
 test('Deterministic assignment', async () => {
   await testDeterministicCode('let a = 5; a = 10; a;', 10)
 })
@@ -46,6 +89,16 @@ test('Test assignment', async () => {
   await testNonDeterministicCode('let a = amb(1, 2); a = amb(4, 5); a;', [4, 5, 4, 5])
 })
 
+test('Test functions with non deterministic terms', async () => {
+  await testNonDeterministicCode(
+    `function foo() {
+      return amb(true, false) ? 'a string' : amb(10, 20);
+     }
+     foo();`,
+    ['a string', 10, 20]
+  )
+})
+
 // ---------------------------------- Helper functions  -------------------------------------------
 
 const nonDetTestOptions = {
@@ -64,14 +117,14 @@ async function testNonDeterministicCode(code: string, expectedValues: any[]) {
   let result: Result = await runInContext(code, context, nonDetTestOptions)
   const numOfRuns = expectedValues.length
   for (let i = 0; i < numOfRuns; i++) {
-    expect((result as SuspendedNonDet).value).toBe(expectedValues[i])
-    expect(result.status).toBe('suspended-non-det')
+    expect((result as SuspendedNonDet).value).toEqual(expectedValues[i])
+    expect(result.status).toEqual('suspended-non-det')
     result = await resume(result)
   }
 
   // all non deterministic programs have a final result whose value is undefined
-  expect(result.status).toBe('finished')
-  expect((result as Finished).value).toBe(undefined)
+  expect(result.status).toEqual('finished')
+  expect((result as Finished).value).toEqual(undefined)
 }
 
 function makeNonDetContext() {

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -3,84 +3,52 @@ import { runInContext, resume, IOptions, Result } from '../index'
 import { mockContext } from '../mocks/context'
 import { SuspendedNonDet, Finished } from '../types'
 
-// ---------------------------------- Deterministic code tests --------------------------------
 test('Empty code returns undefined', async () => {
   await testDeterministicCode('', undefined)
 })
 
-test('Deterministic calculation', async () => {
+test('Unary operations', async () => {
+  await testDeterministicCode('-12 - 8;', -20)
+  await testDeterministicCode('!true;', false)
+  await testDeterministicCode('!(false);', true)
+})
+
+test('Unary operations with non deterministic terms', async () => {
+  await testNonDeterministicCode('-amb(12, 24) - 8;', [-20, -32])
+  await testNonDeterministicCode('!amb(true, false);', [false, true])
+})
+
+test('Binary operations', async () => {
   await testDeterministicCode('1 + 4 - 10 * 5;', -45)
+  await testDeterministicCode('"hello" + " world" + "!";', 'hello world!')
+  await testDeterministicCode('(23 % 3) * (10 / 2);', 10)
 })
 
-test('Deterministic function applications', async () => {
-  await testDeterministicCode(
-    `function factorial(n) {
-      return n === 0 ? 1 : n * factorial(n - 1);
-     }
-     factorial(5);
-    `,
-    120
-  )
-
-  await testDeterministicCode(
-    `function noReturnStatement_returnsUndefined() {
-       20 + 40 - 6;
-       5 - 5;
-       list();
-       reverse(list(1));
-     }`,
-    undefined
-  )
+test('Binary operations with non deterministic terms', async () => {
+  await testNonDeterministicCode('1 + amb(4) - 10 * 5;', [-45])
+  await testNonDeterministicCode('amb("hello", "bye") + " world" + "!";', [
+    'hello world!',
+    'bye world!'
+  ])
+  await testNonDeterministicCode('amb((23 % 3), 7) * amb((10 / 2), 19 - 5);', [10, 28, 35, 98])
 })
 
-test('Deterministic logical expressions', async () => {
-  await testDeterministicCode(`true && (false || true) && (true && false);`, false)
-
-  await testDeterministicCode(
-    `function foo() { return foo(); }\
-      true || foo();`,
-    true
-  )
-
-  await testDeterministicCode(
-    `function foo() { return foo(); }\
-    false && foo();`,
-    false
-  )
-})
-
-test('Test builtin list functions', async () => {
-  await testDeterministicCode('pair(false, 10);', [false, 10])
-  await testDeterministicCode('list();', null)
-  await testDeterministicCode('list(1);', [1, null])
-  await testDeterministicCode('head(list(1));', 1)
-  await testDeterministicCode('tail(list(1));', null)
-})
-
-test('Test prelude list functions', async () => {
-  await testDeterministicCode('is_null(null);', true)
-  await testDeterministicCode('is_null(list(null));', false)
-  await testDeterministicCode(
-    `function increment(n) { return n + 1; }
-     map(increment, list(100, 101, 200));
-    `,
-    [101, [102, [201, null]]]
-  )
-  await testDeterministicCode('append(list(5), list(6,20));', [5, [6, [20, null]]])
-  await testDeterministicCode('append(list(4,5), list());', [4, [5, null]])
-  await testDeterministicCode('reverse(list("hello", true, 0));', [0, [true, ['hello', null]]])
-})
-
-test('Deterministic assignment', async () => {
+test('Assignment', async () => {
   await testDeterministicCode('let a = 5; a = 10; a;', 10)
 })
-// ---------------------------------- Non deterministic code tests -------------------------------
 
-test('Test simple amb application', async () => {
-  await testNonDeterministicCode('amb(1, 4 + 5, 3 - 10);', [1, 9, -7])
+test('Assignment with non deterministic terms', async () => {
+  await testNonDeterministicCode('let a = amb(1, 2); a = amb(4, 5); a;', [4, 5, 4, 5])
+
+  await testNonDeterministicCode(
+    `let num = 5;
+    function reassign_num() { num = 10; return num; }
+    amb(reassign_num(), num);`,
+    [10, 5]
+  )
 })
 
-test('Test if-else and conditional expressions', async () => {
+test('If-else and conditional expressions with non deterministic terms', async () => {
   await testNonDeterministicCode('amb(false, true) ? 4 - 10 : 6;', [6, -6])
   await testNonDeterministicCode(
     `if (amb(true, false)) {
@@ -101,11 +69,100 @@ test('Test if-else and conditional expressions', async () => {
   )
 })
 
-test('Test assignment', async () => {
-  await testNonDeterministicCode('let a = amb(1, 2); a = amb(4, 5); a;', [4, 5, 4, 5])
+test('Logical expressions', async () => {
+  await testDeterministicCode(`true && (false || true) && (true && false);`, false)
+
+  await testDeterministicCode(
+    `function foo() { return foo(); }\
+      true || foo();`,
+    true
+  )
+
+  await testDeterministicCode(
+    `function foo() { return foo(); }\
+    false && foo();`,
+    false
+  )
 })
 
-test('Test functions with non deterministic terms', async () => {
+test('Logical expressions with non deterministic terms', async () => {
+  await testNonDeterministicCode(
+    `amb(true, false) && amb(false, true) || amb(false);
+    `,
+    [false, true, false]
+  )
+})
+
+test('Function applications', async () => {
+  await testDeterministicCode(
+    `function factorial(n) {
+      return n === 0 ? 1 : n * factorial(n - 1);
+     }
+     factorial(5);
+    `,
+    120
+  )
+
+  await testDeterministicCode(
+    'function f(x) { function subfunction(y) {  return y * 2; } return x * subfunction(10); } f(6);',
+    120
+  )
+
+  await testDeterministicCode(
+    `function noReturnStatement_returnsUndefined() {
+       20 + 40 - 6;
+       5 - 5;
+       list();
+       reverse(list(1));
+     }`,
+    undefined
+  )
+})
+
+test('Builtin list functions', async () => {
+  await testDeterministicCode('pair(false, 10);', [false, 10])
+  await testDeterministicCode('list();', null)
+  await testDeterministicCode('list(1);', [1, null])
+  await testDeterministicCode('head(list(1));', 1)
+  await testDeterministicCode('tail(list(1));', null)
+})
+
+test('Builtin list functions with non deterministic terms', async () => {
+  await testNonDeterministicCode('pair(amb(false, true), 10);', [
+    [false, 10],
+    [true, 10]
+  ])
+  await testNonDeterministicCode('list(amb());', [])
+  await testNonDeterministicCode('list(amb(1,2));', [
+    [1, null],
+    [2, null]
+  ])
+  await testNonDeterministicCode('head(amb(list(100), list(20, 30)));', [100, 20])
+})
+
+test('Prelude list functions', async () => {
+  await testDeterministicCode('is_null(null);', true)
+  await testDeterministicCode('is_null(list(null));', false)
+  await testDeterministicCode(
+    `function increment(n) { return n + 1; }
+     map(increment, list(100, 101, 200));
+    `,
+    [101, [102, [201, null]]]
+  )
+  await testDeterministicCode('append(list(5), list(6,20));', [5, [6, [20, null]]])
+  await testDeterministicCode('append(list(4,5), list());', [4, [5, null]])
+  await testDeterministicCode('reverse(list("hello", true, 0));', [0, [true, ['hello', null]]])
+})
+
+test('Empty amb application', async () => {
+  await testNonDeterministicCode('amb();', [])
+})
+
+test('Simple amb application', async () => {
+  await testNonDeterministicCode('amb(1, 4 + 5, 3 - 10);', [1, 9, -7])
+})
+
+test('Functions with non deterministic terms', async () => {
   await testNonDeterministicCode(
     `function foo() {
       return amb(true, false) ? 'a string' : amb(10, 20);
@@ -115,11 +172,39 @@ test('Test functions with non deterministic terms', async () => {
   )
 })
 
-test('Test binary expressions', async () => {
+test('Functions as amb arguments', async () => {
   await testNonDeterministicCode(
-    `amb(true, false) && amb(false, true) || amb(false);
-    `,
-    [false, true, false]
+    ' const is_even = num => (num % 2) === 0;\
+      const add_five = num => num + 5;\
+      const nondet_func = amb(is_even, add_five, num => !is_even(num));\
+      nondet_func(5);\
+    ',
+    [false, 10, true]
+  )
+})
+
+test('Combinations of amb', async () => {
+  await testNonDeterministicCode('list(amb(1, 2, 3), amb("a", "b"));', [
+    [1, ['a', null]],
+    [1, ['b', null]],
+    [2, ['a', null]],
+    [2, ['b', null]],
+    [3, ['a', null]],
+    [3, ['b', null]]
+  ])
+})
+
+test('Require operator', async () => {
+  await testNonDeterministicCode(
+    ' \
+      function int_between(low, high) { \
+        return low > high ? amb() : amb(low, int_between(low + 1, high)); \
+      } \
+      let integer = int_between(5, 10);\
+      require(integer % 3 === 0); \
+      integer;\
+    ',
+    [6, 9]
   )
 })
 
@@ -130,13 +215,13 @@ const nonDetTestOptions = {
   executionMethod: 'interpreter'
 } as Partial<IOptions>
 
-async function testDeterministicCode(code: string, expectedValue: any) {
+export async function testDeterministicCode(code: string, expectedValue: any) {
   /* a deterministic program is equivalent to a non deterministic program
      that returns a single value */
   await testNonDeterministicCode(code, [expectedValue])
 }
 
-async function testNonDeterministicCode(code: string, expectedValues: any[]) {
+export async function testNonDeterministicCode(code: string, expectedValues: any[]) {
   const context = makeNonDetContext()
   let result: Result = await runInContext(code, context, nonDetTestOptions)
   const numOfRuns = expectedValues.length
@@ -152,7 +237,7 @@ async function testNonDeterministicCode(code: string, expectedValues: any[]) {
 }
 
 function makeNonDetContext() {
-  const context = mockContext(4)
+  const context = mockContext(4.3)
   context.executionMethod = 'interpreter'
   return context
 }

--- a/src/__tests__/non-det-sicp-examples.ts
+++ b/src/__tests__/non-det-sicp-examples.ts
@@ -1,0 +1,65 @@
+/* This file uses programs from SICP JS 4.3 as tests for the non deterministic interpreter */
+import { testNonDeterministicCode } from './non-det-interpreter'
+
+test('An element of', async () => {
+  await testNonDeterministicCode(`an_element_of(list(1, 2, list(3, 4)));`, [1, 2, [3, [4, null]]])
+})
+
+test('An integer between', async () => {
+  await testNonDeterministicCode('an_integer_between(5, 10);', [5, 6, 7, 8, 9, 10])
+})
+
+test('Pythagorean triple', async () => {
+  await testNonDeterministicCode(
+    `function a_pythagorean_triple_between(low, high) {
+         const i = an_integer_between(low, high);
+         const j = an_integer_between(i, high);
+         const k = an_integer_between(j, high);
+         require(i * i + j * j === k * k);
+         return list(i, j, k);
+       }
+       a_pythagorean_triple_between(3, 5);`,
+    [[3, [4, [5, null]]]]
+  )
+})
+
+test('Multiple dwelling problem', async () => {
+  await testNonDeterministicCode(
+    `function multiple_dwelling() {
+            const baker = amb(1, 2, 3, 4, 5);
+            const cooper = amb(1, 2, 3, 4, 5);
+            const fletcher = amb(1, 2, 3, 4, 5);
+            const miller = amb(1, 2, 3, 4, 5);
+            const smith = amb(1, 2, 3, 4, 5);
+            require(distinct(list(baker, cooper, fletcher, miller, smith)));
+            require(!(baker === 5));
+            require(!(cooper === 1));
+            require(!(fletcher === 5));
+            require(!(fletcher === 1));
+            require((miller > cooper));
+            require(!(math_abs(smith - fletcher) === 1));
+            require(!(math_abs(fletcher - cooper) === 1));
+            return list(list("baker", baker),
+                        list("cooper", cooper),
+                        list("fletcher", fletcher),
+                        list("miller", miller),
+                        list("smith", smith));
+        }
+        multiple_dwelling();`,
+    [
+      [
+        ['baker', [3, null]],
+        [
+          ['cooper', [2, null]],
+          [
+            ['fletcher', [4, null]],
+            [
+              ['miller', [5, null]],
+              [['smith', [1, null]], null]
+            ]
+          ]
+        ]
+      ]
+    ]
+  )
+})

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+export const CUT = 'cut' // cut operator for Source 4.3
 export const GLOBAL = typeof window === 'undefined' ? global : window
 export const GLOBAL_KEY_TO_ACCESS_NATIVE_STORAGE = '$$NATIVE_STORAGE'
 export const MAX_LIST_DISPLAY_LENGTH = 100

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 import * as es from 'estree'
 
 export const CUT = 'cut' // cut operator for Source 4.3
+export const TRY_AGAIN = 'try again' // command for Source 4.3
 export const GLOBAL = typeof window === 'undefined' ? global : window
 export const GLOBAL_KEY_TO_ACCESS_NATIVE_STORAGE = '$$NATIVE_STORAGE'
 export const MAX_LIST_DISPLAY_LENGTH = 100

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -5,6 +5,7 @@ import { AsyncScheduler } from './schedulers'
 import * as list from './stdlib/list'
 import { list_to_vector } from './stdlib/list'
 import { listPrelude } from './stdlib/list.prelude'
+import { nonDetPrelude } from './stdlib/non-det.prelude'
 import * as misc from './stdlib/misc'
 import * as parser from './stdlib/parser'
 import * as stream from './stdlib/stream'
@@ -205,6 +206,11 @@ function importPrelude(context: Context) {
   if (context.chapter >= 3) {
     prelude += streamPrelude
   }
+
+  if (context.chapter === 4.3) {
+    prelude += nonDetPrelude
+  }
+
   if (prelude !== '') {
     context.prelude = prelude
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,7 +297,7 @@ export async function runInContext(
   } else {
     let it = evaluate(program, context)
     let scheduler: Scheduler
-    if (context.executionMethod === 'non-det-interpreter') {
+    if (theOptions.scheduler === 'non-det') {
       it = nonDetEvaluate(program, context)
       scheduler = new NonDetScheduler()
     } else if (theOptions.scheduler === 'async') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { RuntimeSourceError } from './errors/runtimeSourceError'
 import { findDeclarationNode, findIdentifierNode } from './finder'
 import { evaluate } from './interpreter/interpreter'
 import { parse, parseAt } from './parser/parser'
-import { AsyncScheduler, PreemptiveScheduler } from './schedulers'
+import { AsyncScheduler, PreemptiveScheduler, NonDetScheduler } from './schedulers'
 import { getAllOccurrencesInScopeHelper } from './scope-refactoring'
 import { areBreakpointsSet, setBreakpointAtLine } from './stdlib/inspector'
 import { getEvaluationSteps } from './stepper/stepper'
@@ -29,11 +29,12 @@ import {
   Scheduler,
   SourceError
 } from './types'
+import { nonDetEvaluate } from './interpreter/interpreter-non-det'
 import { locationDummyNode } from './utils/astCreator'
 import { validateAndAnnotate } from './validator/validator'
 
 export interface IOptions {
-  scheduler: 'preemptive' | 'async'
+  scheduler: 'preemptive' | 'async' | 'non-det'
   steps: number
   executionMethod: ExecutionMethod
   evaluationMethod: EvaluationMethod
@@ -294,9 +295,12 @@ export async function runInContext(
       )
     }
   } else {
-    const it = evaluate(program, context)
+    let it = evaluate(program, context)
     let scheduler: Scheduler
-    if (theOptions.scheduler === 'async') {
+    if (context.executionMethod === 'non-det-interpreter') {
+      it = nonDetEvaluate(program, context)
+      scheduler = new NonDetScheduler()
+    } else if (theOptions.scheduler === 'async') {
       scheduler = new AsyncScheduler()
     } else {
       scheduler = new PreemptiveScheduler(theOptions.steps)

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -1,0 +1,706 @@
+/* tslint:disable:max-classes-per-file */
+import * as es from 'estree'
+import * as constants from '../constants'
+import * as errors from '../errors/errors'
+import { RuntimeSourceError } from '../errors/runtimeSourceError'
+import { Context, Environment, Frame, Value } from '../types'
+import { conditionalExpression, literal, primitive } from '../utils/astCreator'
+import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
+import * as rttc from '../utils/rttc'
+import Closure from './closure'
+import { cloneDeep, assignIn } from 'lodash'
+import { CUT } from '../constants'
+
+class BreakValue {}
+
+class ContinueValue {}
+
+class ReturnValue {
+  constructor(public value: Value) {}
+}
+
+class TailCallReturnValue {
+  constructor(public callee: Closure, public args: Value[], public node: es.CallExpression) {}
+}
+
+const createEnvironment = (
+  closure: Closure,
+  args: Value[],
+  callExpression?: es.CallExpression
+): Environment => {
+  const environment: Environment = {
+    name: closure.functionName, // TODO: Change this
+    tail: closure.environment,
+    head: {}
+  }
+  if (callExpression) {
+    environment.callExpression = {
+      ...callExpression,
+      arguments: args.map(primitive)
+    }
+  }
+  closure.node.params.forEach((param, index) => {
+    const ident = param as es.Identifier
+    environment.head[ident.name] = args[index]
+  })
+  return environment
+}
+
+const createBlockEnvironment = (
+  context: Context,
+  name = 'blockEnvironment',
+  head: Frame = {}
+): Environment => {
+  return {
+    name,
+    tail: currentEnvironment(context),
+    head,
+    thisContext: context
+  }
+}
+
+const handleRuntimeError = (context: Context, error: RuntimeSourceError): never => {
+  context.errors.push(error)
+  context.runtime.environments = context.runtime.environments.slice(
+    -context.numberOfOuterEnvironments
+  )
+  throw error
+}
+
+const HOISTED_BUT_NOT_YET_ASSIGNED = Symbol('Used to implement hoisting')
+
+function hoistIdentifier(context: Context, name: string, node: es.Node) {
+  const environment = currentEnvironment(context)
+  if (environment.head.hasOwnProperty(name)) {
+    const descriptors = Object.getOwnPropertyDescriptors(environment.head)
+
+    return handleRuntimeError(
+      context,
+      new errors.VariableRedeclaration(node, name, descriptors[name].writable)
+    )
+  }
+  environment.head[name] = HOISTED_BUT_NOT_YET_ASSIGNED
+  return environment
+}
+
+function hoistVariableDeclarations(context: Context, node: es.VariableDeclaration) {
+  for (const declaration of node.declarations) {
+    hoistIdentifier(context, (declaration.id as es.Identifier).name, node)
+  }
+}
+
+function hoistFunctionsAndVariableDeclarationsIdentifiers(
+  context: Context,
+  node: es.BlockStatement
+) {
+  for (const statement of node.body) {
+    switch (statement.type) {
+      case 'VariableDeclaration':
+        hoistVariableDeclarations(context, statement)
+        break
+      case 'FunctionDeclaration':
+        hoistIdentifier(context, (statement.id as es.Identifier).name, statement)
+        break
+    }
+  }
+}
+
+function defineVariable(context: Context, name: string, value: Value, constant = false) {
+  const environment = context.runtime.environments[0]
+
+  if (environment.head[name] !== HOISTED_BUT_NOT_YET_ASSIGNED) {
+    return handleRuntimeError(
+      context,
+      new errors.VariableRedeclaration(context.runtime.nodes[0]!, name, !constant)
+    )
+  }
+
+  Object.defineProperty(environment.head, name, {
+    value,
+    writable: !constant,
+    enumerable: true
+  })
+
+  return environment
+}
+
+const currentEnvironment = (context: Context) => context.runtime.environments[0]
+const replaceEnvironment = (context: Context, environment: Environment) =>
+  (context.runtime.environments[0] = environment)
+const popEnvironment = (context: Context) => context.runtime.environments.shift()
+const pushEnvironment = (context: Context, environment: Environment) =>
+  context.runtime.environments.unshift(environment)
+
+const getVariable = (context: Context, name: string) => {
+  let environment: Environment | null = context.runtime.environments[0]
+  while (environment) {
+    if (environment.head.hasOwnProperty(name)) {
+      if (environment.head[name] === HOISTED_BUT_NOT_YET_ASSIGNED) {
+        return handleRuntimeError(
+          context,
+          new errors.UnassignedVariable(name, context.runtime.nodes[0])
+        )
+      } else {
+        return environment.head[name]
+      }
+    } else {
+      environment = environment.tail
+    }
+  }
+  return handleRuntimeError(context, new errors.UndefinedVariable(name, context.runtime.nodes[0]))
+}
+
+const setVariable = (context: Context, name: string, value: any) => {
+  let environment: Environment | null = context.runtime.environments[0]
+  while (environment) {
+    if (environment.head.hasOwnProperty(name)) {
+      if (environment.head[name] === HOISTED_BUT_NOT_YET_ASSIGNED) {
+        break
+      }
+      const descriptors = Object.getOwnPropertyDescriptors(environment.head)
+      if (descriptors[name].writable) {
+        environment.head[name] = value
+        return undefined
+      }
+      return handleRuntimeError(
+        context,
+        new errors.ConstAssignment(context.runtime.nodes[0]!, name)
+      )
+    } else {
+      environment = environment.tail
+    }
+  }
+  return handleRuntimeError(context, new errors.UndefinedVariable(name, context.runtime.nodes[0]))
+}
+
+const checkNumberOfArguments = (
+  context: Context,
+  callee: Closure,
+  args: Value[],
+  exp: es.CallExpression
+) => {
+  if (callee.node.params.length !== args.length) {
+    return handleRuntimeError(
+      context,
+      new errors.InvalidNumberOfArguments(exp, callee.node.params.length, args.length)
+    )
+  }
+  return undefined
+}
+
+function* getArgs(context: Context, call: es.CallExpression) {
+  const args = []
+  for (const arg of call.arguments) {
+    args.push(yield* evaluate(arg, context))
+  }
+  return args
+}
+
+function* getAmbArgs(context: Context, call: es.CallExpression) {
+  const originalContext = cloneDeep(context)
+  for (const arg of call.arguments) {
+    yield* evaluate(arg, context)
+    assignIn(context, cloneDeep(originalContext)) // reset context
+  }
+}
+
+function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalExpression {
+  if (node.operator === '&&') {
+    return conditionalExpression(node.left, node.right, literal(false), node.loc!)
+  } else {
+    return conditionalExpression(node.left, literal(true), node.right, node.loc!)
+  }
+}
+
+function* evaluateRequire(context: Context, call: es.CallExpression) {
+  // TODO: Throw an error if require does not have 0 arguments
+  const predicate = call.arguments[0]
+  const predicateGenerator = evaluate(predicate, context)
+  let predicateValue = predicateGenerator.next()
+
+  while (!predicateValue.done) {
+    if (predicateValue.value) {
+      yield 'Satisfied require'
+    }
+    predicateValue = predicateGenerator.next()
+  }
+}
+
+function* reduceIf(
+  node: es.IfStatement | es.ConditionalExpression,
+  context: Context
+): IterableIterator<es.Node> {
+  const test = yield* evaluate(node.test, context)
+
+  const error = rttc.checkIfStatement(node, test)
+  if (error) {
+    return handleRuntimeError(context, error)
+  }
+
+  return test ? node.consequent : node.alternate
+}
+
+export type Evaluator<T extends es.Node> = (node: T, context: Context) => IterableIterator<Value>
+
+function* evaluateBlockSatement(context: Context, node: es.BlockStatement) {
+  hoistFunctionsAndVariableDeclarationsIdentifiers(context, node)
+  yield* evaluateSequence(context, node.body)
+}
+
+function* evaluateSequence(context: Context, sequence: es.Statement[]): IterableIterator<Value> {
+  if (sequence.length === 0) {
+    return yield undefined // repl does not work unless we handle this case --> Why?
+  }
+  const firstStatement = sequence[0]
+  const sequenceValGenerator = evaluate(firstStatement, context)
+  if (sequence.length === 1) {
+    yield* sequenceValGenerator
+  } else {
+    sequence.shift()
+    let sequenceValue = sequenceValGenerator.next()
+
+    // prevent unshifting of cut operator
+    let shouldUnshift = sequenceValue.value !== CUT
+
+    while (!sequenceValue.done) {
+      const res = yield* evaluateSequence(context, sequence)
+      if (res === CUT) {
+        // prevent unshifting of statenents before cut
+        shouldUnshift = false
+        break
+      }
+
+      sequenceValue = sequenceValGenerator.next()
+    }
+
+    if (shouldUnshift) sequence.unshift(firstStatement)
+    else return CUT
+  }
+}
+
+/**
+ * WARNING: Do not use object literal shorthands, e.g.
+ *   {
+ *     *Literal(node: es.Literal, ...) {...},
+ *     *ThisExpression(node: es.ThisExpression, ..._ {...},
+ *     ...
+ *   }
+ * They do not minify well, raising uncaught syntax errors in production.
+ * See: https://github.com/webpack/webpack/issues/7566
+ */
+// tslint:disable:object-literal-shorthand
+// prettier-ignore
+export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
+  /** Simple Values */
+  Literal: function*(node: es.Literal, context: Context) {
+    yield node.value
+  },
+
+  ThisExpression: function*(node: es.ThisExpression, context: Context) {
+    return context.runtime.environments[0].thisContext
+  },
+
+  ArrayExpression: function*(node: es.ArrayExpression, context: Context) {
+    const res = []
+    for (const n of node.elements) {
+      res.push(yield* evaluate(n, context))
+    }
+    return res
+  },
+
+  DebuggerStatement: function*(node: es.DebuggerStatement, context: Context) {
+    context.runtime.break = true
+    yield
+  },
+
+  FunctionExpression: function*(node: es.FunctionExpression, context: Context) {
+    return new Closure(node, currentEnvironment(context), context)
+  },
+
+  ArrowFunctionExpression: function*(node: es.ArrowFunctionExpression, context: Context) {
+    return Closure.makeFromArrowFunction(node, currentEnvironment(context), context)
+  },
+
+  Identifier: function*(node: es.Identifier, context: Context) {
+    if (node.name === 'cut') {
+      return yield CUT
+    }
+
+    yield getVariable(context, node.name)
+    return
+  },
+
+  CallExpression: function*(node: es.CallExpression, context: Context) {
+    const callee = node.callee as es.Identifier;
+    if (callee.name === 'amb') {
+      yield* getAmbArgs(context, node)
+    }
+
+    if (callee.name === 'require') {
+      yield* evaluateRequire(context, node)
+    }
+
+    /*
+    const callee = yield* evaluate(node.callee, context)
+    const args = yield* getArgs(context, node)
+    let thisContext
+    if (node.callee.type === 'MemberExpression') {
+      thisContext = yield* evaluate(node.callee.object, context)
+    }
+    const result = yield* apply(context, callee, args, node, thisContext)
+    return result */
+  },
+
+  NewExpression: function*(node: es.NewExpression, context: Context) {
+    const callee = yield* evaluate(node.callee, context)
+    const args = []
+    for (const arg of node.arguments) {
+      args.push(yield* evaluate(arg, context))
+    }
+    const obj: Value = {}
+    if (callee instanceof Closure) {
+      obj.__proto__ = callee.fun.prototype
+      callee.fun.apply(obj, args)
+    } else {
+      obj.__proto__ = callee.prototype
+      callee.apply(obj, args)
+    }
+    return obj
+  },
+
+  UnaryExpression: function*(node: es.UnaryExpression, context: Context) {
+    const argGenerator = evaluate(node.argument, context)
+    let argValue = argGenerator.next()
+
+    while (!argValue.done) {
+      const error = rttc.checkUnaryExpression(node, node.operator, argValue.value)
+      if (error) {
+        return handleRuntimeError(context, error)
+      }
+
+      yield evaluateUnaryExpression(node.operator, argValue.value)
+      argValue = argGenerator.next()
+    }
+    return
+  },
+
+  BinaryExpression: function*(node: es.BinaryExpression, context: Context) {
+    const leftGenerator = evaluate(node.left, context)
+    let leftValue = leftGenerator.next();
+
+    while (!leftValue.done) {
+      const rightGenerator = evaluate(node.right, context)
+      let rightValue = rightGenerator.next();
+      while (!rightValue.done) {
+        const error = rttc.checkBinaryExpression(node, node.operator, leftValue.value, rightValue.value)
+        if (error) {
+          return handleRuntimeError(context, error)
+        }
+        yield evaluateBinaryExpression(node.operator, leftValue.value, rightValue.value)
+        rightValue = rightGenerator.next();
+      }
+
+      leftValue = leftGenerator.next();
+    }
+    return
+  },
+
+  VariableDeclaration: function*(node: es.VariableDeclaration, context: Context) {
+    const declaration = node.declarations[0]
+    const constant = node.kind === 'const'
+    const id = declaration.id as es.Identifier
+    const valueGenerator = evaluate(declaration.init!, context)
+    let value = valueGenerator.next()
+
+    while(!value.done) {
+      defineVariable(context, id.name, value.value, constant)
+      yield "Declared variable " + id.name + " with value " + value.value
+      value = valueGenerator.next()
+    }
+    return undefined
+  },
+
+  ContinueStatement: function*(node: es.ContinueStatement, context: Context) {
+    return new ContinueValue()
+  },
+
+  BreakStatement: function*(node: es.BreakStatement, context: Context) {
+    return new BreakValue()
+  },
+
+  ForStatement: function*(node: es.ForStatement, context: Context) {
+    // Create a new block scope for the loop variables
+    const loopEnvironment = createBlockEnvironment(context, 'forLoopEnvironment')
+    pushEnvironment(context, loopEnvironment)
+
+    const initNode = node.init!
+    const testNode = node.test!
+    const updateNode = node.update!
+    if (initNode.type === 'VariableDeclaration') {
+      hoistVariableDeclarations(context, initNode)
+    }
+    yield* evaluate(initNode, context)
+
+    let value
+    while (yield* evaluate(testNode, context)) {
+      // create block context and shallow copy loop environment head
+      // see https://www.ecma-international.org/ecma-262/6.0/#sec-for-statement-runtime-semantics-labelledevaluation
+      // and https://hacks.mozilla.org/2015/07/es6-in-depth-let-and-const/
+      // We copy this as a const to avoid ES6 funkiness when mutating loop vars
+      // https://github.com/source-academy/js-slang/issues/65#issuecomment-425618227
+      const environment = createBlockEnvironment(context, 'forBlockEnvironment')
+      pushEnvironment(context, environment)
+      for (const name in loopEnvironment.head) {
+        if (loopEnvironment.head.hasOwnProperty(name)) {
+          hoistIdentifier(context, name, node)
+          defineVariable(context, name, loopEnvironment.head[name], true)
+        }
+      }
+
+      value = yield* evaluate(node.body, context)
+
+      // Remove block context
+      popEnvironment(context)
+      if (value instanceof ContinueValue) {
+        value = undefined
+      }
+      if (value instanceof BreakValue) {
+        value = undefined
+        break
+      }
+      if (value instanceof ReturnValue || value instanceof TailCallReturnValue) {
+        break
+      }
+
+      yield* evaluate(updateNode, context)
+    }
+
+    popEnvironment(context)
+
+    return value
+  },
+
+  MemberExpression: function*(node: es.MemberExpression, context: Context) {
+    let obj = yield* evaluate(node.object, context)
+    if (obj instanceof Closure) {
+      obj = obj.fun
+    }
+    let prop
+    if (node.computed) {
+      prop = yield* evaluate(node.property, context)
+    } else {
+      prop = (node.property as es.Identifier).name
+    }
+
+    const error = rttc.checkMemberAccess(node, obj, prop)
+    if (error) {
+      return handleRuntimeError(context, error)
+    }
+
+    if (
+      obj !== null &&
+      obj !== undefined &&
+      typeof obj[prop] !== 'undefined' &&
+      !obj.hasOwnProperty(prop)
+    ) {
+      return handleRuntimeError(context, new errors.GetInheritedPropertyError(node, obj, prop))
+    }
+    try {
+      return obj[prop]
+    } catch {
+      return handleRuntimeError(context, new errors.GetPropertyError(node, obj, prop))
+    }
+  },
+
+  AssignmentExpression: function*(node: es.AssignmentExpression, context: Context) {
+    if (node.left.type === 'MemberExpression') {
+      const left = node.left
+      const obj = yield* evaluate(left.object, context)
+      let prop
+      if (left.computed) {
+        prop = yield* evaluate(left.property, context)
+      } else {
+        prop = (left.property as es.Identifier).name
+      }
+
+      const error = rttc.checkMemberAccess(node, obj, prop)
+      if (error) {
+        return handleRuntimeError(context, error)
+      }
+
+      const val = yield* evaluate(node.right, context)
+      try {
+        obj[prop] = val
+      } catch {
+        return handleRuntimeError(context, new errors.SetPropertyError(node, obj, prop))
+      }
+      return val
+    }
+    const id = node.left as es.Identifier
+    // Make sure it exist
+    const value = yield* evaluate(node.right, context)
+    setVariable(context, id.name, value)
+    return value
+  },
+
+  FunctionDeclaration: function*(node: es.FunctionDeclaration, context: Context) {
+    const id = node.id as es.Identifier
+    // tslint:disable-next-line:no-any
+    const closure = new Closure(node, currentEnvironment(context), context)
+    defineVariable(context, id.name, closure, true)
+    return undefined
+  },
+
+  IfStatement: function*(node: es.IfStatement | es.ConditionalExpression, context: Context) {
+    return yield* evaluate(yield* reduceIf(node, context), context)
+  },
+
+  ExpressionStatement: function*(node: es.ExpressionStatement, context: Context) {
+    return yield* evaluate(node.expression, context)
+  },
+
+  ReturnStatement: function*(node: es.ReturnStatement, context: Context) {
+    let returnExpression = node.argument!
+
+    // If we have a conditional expression, reduce it until we get something else
+    while (
+      returnExpression.type === 'LogicalExpression' ||
+      returnExpression.type === 'ConditionalExpression'
+    ) {
+      if (returnExpression.type === 'LogicalExpression') {
+        returnExpression = transformLogicalExpression(returnExpression)
+      }
+      returnExpression = yield* reduceIf(returnExpression, context)
+    }
+
+    // If we are now left with a CallExpression, then we use TCO
+    if (returnExpression.type === 'CallExpression') {
+      const callee = yield* evaluate(returnExpression.callee, context)
+      const args = yield* getArgs(context, returnExpression)
+      return new TailCallReturnValue(callee, args, returnExpression)
+    } else {
+      return new ReturnValue(yield* evaluate(returnExpression, context))
+    }
+  },
+
+  WhileStatement: function*(node: es.WhileStatement, context: Context) {
+    let value: any // tslint:disable-line
+    while (
+      // tslint:disable-next-line
+      (yield* evaluate(node.test, context)) &&
+      !(value instanceof ReturnValue) &&
+      !(value instanceof BreakValue) &&
+      !(value instanceof TailCallReturnValue)
+    ) {
+      value = yield* evaluate(node.body, context)
+    }
+    if (value instanceof BreakValue) {
+      return undefined
+    }
+    return value
+  },
+
+  ObjectExpression: function*(node: es.ObjectExpression, context: Context) {
+    const obj = {}
+    for (const prop of node.properties) {
+      let key
+      if (prop.key.type === 'Identifier') {
+        key = prop.key.name
+      } else {
+        key = yield* evaluate(prop.key, context)
+      }
+      obj[key] = yield* evaluate(prop.value, context)
+    }
+    return obj
+  },
+
+  BlockStatement: function*(node: es.BlockStatement, context: Context) {
+    let result: Value
+
+    // Create a new environment (block scoping)
+    const environment = createBlockEnvironment(context, 'blockEnvironment')
+    pushEnvironment(context, environment)
+    result = yield* evaluateBlockSatement(context, node)
+    popEnvironment(context)
+    return result
+  },
+
+  Program: function*(node: es.BlockStatement, context: Context) {
+    context.numberOfOuterEnvironments += 1
+    const environment = createBlockEnvironment(context, 'programEnvironment')
+    pushEnvironment(context, environment)
+    return yield* evaluateBlockSatement(context, node)
+  }
+}
+// tslint:enable:object-literal-shorthand
+
+export function* evaluate(node: es.Node, context: Context) {
+  const result = yield* evaluators[node.type](node, context)
+  return result
+}
+
+export function* apply(
+  context: Context,
+  fun: Closure | Value,
+  args: Value[],
+  node: es.CallExpression,
+  thisContext?: Value
+) {
+  let result: Value
+  let total = 0
+
+  while (!(result instanceof ReturnValue)) {
+    if (fun instanceof Closure) {
+      checkNumberOfArguments(context, fun, args, node!)
+      const environment = createEnvironment(fun, args, node)
+      environment.thisContext = thisContext
+      if (result instanceof TailCallReturnValue) {
+        replaceEnvironment(context, environment)
+      } else {
+        pushEnvironment(context, environment)
+        total++
+      }
+      result = yield* evaluateBlockSatement(context, fun.node.body as es.BlockStatement)
+      if (result instanceof TailCallReturnValue) {
+        fun = result.callee
+        node = result.node
+        args = result.args
+      } else if (!(result instanceof ReturnValue)) {
+        // No Return Value, set it as undefined
+        result = new ReturnValue(undefined)
+      }
+    } else if (typeof fun === 'function') {
+      try {
+        result = fun.apply(thisContext, args)
+        break
+      } catch (e) {
+        // Recover from exception
+        context.runtime.environments = context.runtime.environments.slice(
+          -context.numberOfOuterEnvironments
+        )
+
+        const loc = node ? node.loc! : constants.UNKNOWN_LOCATION
+        if (!(e instanceof RuntimeSourceError || e instanceof errors.ExceptionError)) {
+          // The error could've arisen when the builtin called a source function which errored.
+          // If the cause was a source error, we don't want to include the error.
+          // However if the error came from the builtin itself, we need to handle it.
+          return handleRuntimeError(context, new errors.ExceptionError(e, loc))
+        }
+        result = undefined
+        throw e
+      }
+    } else {
+      return handleRuntimeError(context, new errors.CallingNonFunctionValue(fun, node))
+    }
+  }
+  // Unwraps return value and release stack environment
+  if (result instanceof ReturnValue) {
+    result = result.value
+  }
+  for (let i = 1; i <= total; i++) {
+    popEnvironment(context)
+  }
+  return result
+}
+
+export { evaluate as nonDetEvaluate }

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -213,7 +213,13 @@ function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalE
 }
 
 function* evaluateRequire(context: Context, call: es.CallExpression) {
-  // TODO: Throw an error if require does not have 0 arguments
+  if (call.arguments.length !== 1) {
+    return yield handleRuntimeError(
+      context,
+      new errors.InvalidNumberOfArguments(call, 1, call.arguments.length)
+    )
+  }
+
   const predicate = call.arguments[0]
   const predicateGenerator = evaluate(predicate, context)
   let predicateValue = predicateGenerator.next()

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -11,16 +11,8 @@ import Closure from './closure'
 import { cloneDeep, assignIn } from 'lodash'
 import { CUT } from '../constants'
 
-class BreakValue {}
-
-class ContinueValue {}
-
 class ReturnValue {
   constructor(public value: Value) {}
-}
-
-class TailCallReturnValue {
-  constructor(public callee: Closure, public args: Value[], public node: es.CallExpression) {}
 }
 
 const createEnvironment = (
@@ -324,23 +316,6 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     yield node.value
   },
 
-  ThisExpression: function*(node: es.ThisExpression, context: Context) {
-    return context.runtime.environments[0].thisContext
-  },
-
-  ArrayExpression: function*(node: es.ArrayExpression, context: Context) {
-    const res = []
-    for (const n of node.elements) {
-      res.push(yield* evaluate(n, context))
-    }
-    return res
-  },
-
-  DebuggerStatement: function*(node: es.DebuggerStatement, context: Context) {
-    context.runtime.break = true
-    yield
-  },
-
   FunctionExpression: function*(node: es.FunctionExpression, context: Context) {
     yield new Closure(node, currentEnvironment(context), context)
   },
@@ -375,23 +350,6 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
         yield* apply(context, calleeValue, args, node, undefined)
       }
     }
-  },
-
-  NewExpression: function*(node: es.NewExpression, context: Context) {
-    const callee = yield* evaluate(node.callee, context)
-    const args = []
-    for (const arg of node.arguments) {
-      args.push(yield* evaluate(arg, context))
-    }
-    const obj: Value = {}
-    if (callee instanceof Closure) {
-      obj.__proto__ = callee.fun.prototype
-      callee.fun.apply(obj, args)
-    } else {
-      obj.__proto__ = callee.prototype
-      callee.apply(obj, args)
-    }
-    return obj
   },
 
   UnaryExpression: function*(node: es.UnaryExpression, context: Context) {
@@ -442,98 +400,6 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return undefined
   },
 
-  ContinueStatement: function*(node: es.ContinueStatement, context: Context) {
-    return new ContinueValue()
-  },
-
-  BreakStatement: function*(node: es.BreakStatement, context: Context) {
-    return new BreakValue()
-  },
-
-  ForStatement: function*(node: es.ForStatement, context: Context) {
-    // Create a new block scope for the loop variables
-    const loopEnvironment = createBlockEnvironment(context, 'forLoopEnvironment')
-    pushEnvironment(context, loopEnvironment)
-
-    const initNode = node.init!
-    const testNode = node.test!
-    const updateNode = node.update!
-    if (initNode.type === 'VariableDeclaration') {
-      hoistVariableDeclarations(context, initNode)
-    }
-    yield* evaluate(initNode, context)
-
-    let value
-    while (yield* evaluate(testNode, context)) {
-      // create block context and shallow copy loop environment head
-      // see https://www.ecma-international.org/ecma-262/6.0/#sec-for-statement-runtime-semantics-labelledevaluation
-      // and https://hacks.mozilla.org/2015/07/es6-in-depth-let-and-const/
-      // We copy this as a const to avoid ES6 funkiness when mutating loop vars
-      // https://github.com/source-academy/js-slang/issues/65#issuecomment-425618227
-      const environment = createBlockEnvironment(context, 'forBlockEnvironment')
-      pushEnvironment(context, environment)
-      for (const name in loopEnvironment.head) {
-        if (loopEnvironment.head.hasOwnProperty(name)) {
-          hoistIdentifier(context, name, node)
-          defineVariable(context, name, loopEnvironment.head[name], true)
-        }
-      }
-
-      value = yield* evaluate(node.body, context)
-
-      // Remove block context
-      popEnvironment(context)
-      if (value instanceof ContinueValue) {
-        value = undefined
-      }
-      if (value instanceof BreakValue) {
-        value = undefined
-        break
-      }
-      if (value instanceof ReturnValue || value instanceof TailCallReturnValue) {
-        break
-      }
-
-      yield* evaluate(updateNode, context)
-    }
-
-    popEnvironment(context)
-
-    return value
-  },
-
-  MemberExpression: function*(node: es.MemberExpression, context: Context) {
-    let obj = yield* evaluate(node.object, context)
-    if (obj instanceof Closure) {
-      obj = obj.fun
-    }
-    let prop
-    if (node.computed) {
-      prop = yield* evaluate(node.property, context)
-    } else {
-      prop = (node.property as es.Identifier).name
-    }
-
-    const error = rttc.checkMemberAccess(node, obj, prop)
-    if (error) {
-      return handleRuntimeError(context, error)
-    }
-
-    if (
-      obj !== null &&
-      obj !== undefined &&
-      typeof obj[prop] !== 'undefined' &&
-      !obj.hasOwnProperty(prop)
-    ) {
-      return handleRuntimeError(context, new errors.GetInheritedPropertyError(node, obj, prop))
-    }
-    try {
-      return obj[prop]
-    } catch {
-      return handleRuntimeError(context, new errors.GetPropertyError(node, obj, prop))
-    }
-  },
-
   AssignmentExpression: function*(node: es.AssignmentExpression, context: Context) {
     const id = node.left as es.Identifier
 
@@ -567,37 +433,6 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     for (const returnValue of returnValueGenerator) {
       yield new ReturnValue(returnValue)
     }
-  },
-
-  WhileStatement: function*(node: es.WhileStatement, context: Context) {
-    let value: any // tslint:disable-line
-    while (
-      // tslint:disable-next-line
-      (yield* evaluate(node.test, context)) &&
-      !(value instanceof ReturnValue) &&
-      !(value instanceof BreakValue) &&
-      !(value instanceof TailCallReturnValue)
-    ) {
-      value = yield* evaluate(node.body, context)
-    }
-    if (value instanceof BreakValue) {
-      return undefined
-    }
-    return value
-  },
-
-  ObjectExpression: function*(node: es.ObjectExpression, context: Context) {
-    const obj = {}
-    for (const prop of node.properties) {
-      let key
-      if (prop.key.type === 'Identifier') {
-        key = prop.key.name
-      } else {
-        key = yield* evaluate(prop.key, context)
-      }
-      obj[key] = yield* evaluate(prop.value, context)
-    }
-    return obj
   },
 
   BlockStatement: function*(node: es.BlockStatement, context: Context) {

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -4,7 +4,7 @@ import * as constants from '../constants'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { Context, Environment, Frame, Value } from '../types'
-import { primitive } from '../utils/astCreator'
+import { primitive, conditionalExpression, literal } from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
 import Closure from './closure'
@@ -221,14 +221,14 @@ function* getAmbArgs(context: Context, call: es.CallExpression) {
     assignIn(context, cloneDeep(originalContext)) // reset context
   }
 }
-/*
+
 function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalExpression {
   if (node.operator === '&&') {
     return conditionalExpression(node.left, node.right, literal(false), node.loc!)
   } else {
     return conditionalExpression(node.left, literal(true), node.right, node.loc!)
   }
-}*/
+}
 
 function* evaluateRequire(context: Context, call: es.CallExpression) {
   if (call.arguments.length !== 1) {
@@ -453,6 +453,11 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
 
   ConditionalExpression: function*(node: es.ConditionalExpression, context: Context) {
     yield* evaluateConditional(node, context)
+  },
+
+  LogicalExpression: function*(node: es.LogicalExpression, context: Context) {
+    const conditional: es.ConditionalExpression = transformLogicalExpression(node)
+    yield* evaluateConditional(conditional, context)
   },
 
   VariableDeclaration: function*(node: es.VariableDeclaration, context: Context) {

--- a/src/repl/repl-non-det.ts
+++ b/src/repl/repl-non-det.ts
@@ -1,0 +1,105 @@
+import fs = require('fs')
+import repl = require('repl') // 'repl' here refers to the module named 'repl' in index.d.ts
+import util = require('util')
+import { createContext, IOptions, parseError, runInContext, resume, Result } from '../index'
+import { SuspendedNonDet, Context } from '../types'
+import { CUT } from '../constants'
+
+// stores the result obtained when execution is suspended
+let previousResult: Result
+function _handleResult(
+  result: Result,
+  context: Context,
+  callback: (err: Error | null, result: any) => void
+) {
+  if (result.status === 'finished' || result.status === 'suspended-non-det') {
+    previousResult = result
+
+    if (result.value === CUT) result.value = undefined
+    callback(null, result.value)
+  } else {
+    callback(new Error(parseError(context.errors)), undefined)
+    return
+  }
+}
+
+function _resume(
+  toResume: SuspendedNonDet,
+  context: Context,
+  callback: (err: Error | null, result: any) => void
+) {
+  Promise.resolve(resume(toResume)).then((result: Result) => {
+    _handleResult(result, context, callback)
+  })
+}
+
+function _try_again(context: Context, callback: (err: Error | null, result: any) => void) {
+  if (previousResult && previousResult.status === 'suspended-non-det') {
+    _resume(previousResult, context, callback)
+  } else {
+    callback(null, undefined)
+  }
+}
+
+function _run(
+  cmd: string,
+  context: Context,
+  options: Partial<IOptions>,
+  callback: (err: Error | null, result: any) => void
+) {
+  if (cmd.trim() === 'try_again;') {
+    _try_again(context, callback)
+  } else {
+    runInContext(cmd, context, options).then(result => {
+      _handleResult(result, context, callback)
+    })
+  }
+}
+
+function _startRepl(chapter = 1, useSubst: boolean, prelude = '') {
+  // use defaults for everything
+  const context = createContext(chapter)
+  const options: Partial<IOptions> = { scheduler: 'preemptive', useSubst }
+  context.executionMethod = 'non-det-interpreter'
+  runInContext(prelude, context, options).then(preludeResult => {
+    if (preludeResult.status === 'finished' || preludeResult.status === 'suspended-non-det') {
+      console.dir(preludeResult.value, { depth: null })
+
+      repl.start(
+        // the object being passed as argument fits the interface ReplOptions in the repl module.
+        {
+          eval: (cmd, unusedContext, unusedFilename, callback) => {
+            _run(cmd, context, options, callback)
+          },
+          // set depth to a large number so that `parse()` output will not be folded,
+          // setting to null also solves the problem, however a reference loop might crash
+          writer: output =>
+            util.inspect(output, {
+              depth: 1000,
+              colors: true
+            })
+        }
+      )
+    } else {
+      throw new Error(parseError(context.errors))
+    }
+  })
+}
+
+function main() {
+  const firstArg = process.argv[2]
+  if (process.argv.length === 3 && String(Number(firstArg)) !== firstArg.trim()) {
+    fs.readFile(firstArg, 'utf8', (err, data) => {
+      if (err) {
+        throw err
+      }
+      _startRepl(4, false, data)
+    })
+  } else {
+    const chapter = process.argv.length > 2 ? parseInt(firstArg, 10) : 1
+    const useSubst = process.argv.length > 3 ? process.argv[3] === 'subst' : false
+    _startRepl(chapter, useSubst)
+  }
+}
+
+main()

--- a/src/repl/repl-non-det.ts
+++ b/src/repl/repl-non-det.ts
@@ -3,7 +3,7 @@ import repl = require('repl') // 'repl' here refers to the module named 'repl' i
 import util = require('util')
 import { createContext, IOptions, parseError, runInContext, resume, Result } from '../index'
 import { SuspendedNonDet, Context } from '../types'
-import { CUT } from '../constants'
+import { CUT, TRY_AGAIN } from '../constants'
 
 // stores the result obtained when execution is suspended
 let previousResult: Result
@@ -47,7 +47,7 @@ function _run(
   options: Partial<IOptions>,
   callback: (err: Error | null, result: any) => void
 ) {
-  if (cmd.trim() === 'try_again;') {
+  if (cmd.trim() === TRY_AGAIN) {
     _try_again(context, callback)
   } else {
     runInContext(cmd, context, options).then(result => {
@@ -59,8 +59,11 @@ function _run(
 function _startRepl(chapter = 1, useSubst: boolean, prelude = '') {
   // use defaults for everything
   const context = createContext(chapter)
-  const options: Partial<IOptions> = { scheduler: 'preemptive', useSubst }
-  context.executionMethod = 'non-det-interpreter'
+  const options: Partial<IOptions> = {
+    scheduler: 'non-det',
+    executionMethod: 'interpreter',
+    useSubst
+  }
   runInContext(prelude, context, options).then(preludeResult => {
     if (preludeResult.status === 'finished' || preludeResult.status === 'suspended-non-det') {
       console.dir(preludeResult.value, { depth: null })
@@ -93,10 +96,10 @@ function main() {
       if (err) {
         throw err
       }
-      _startRepl(4, false, data)
+      _startRepl(4.3, false, data)
     })
   } else {
-    const chapter = process.argv.length > 2 ? parseInt(firstArg, 10) : 1
+    const chapter = 4.3
     const useSubst = process.argv.length > 3 ? process.argv[3] === 'subst' : false
     _startRepl(chapter, useSubst)
   }

--- a/src/schedulers.ts
+++ b/src/schedulers.ts
@@ -35,6 +35,31 @@ export class AsyncScheduler implements Scheduler {
   }
 }
 
+export class NonDetScheduler implements Scheduler {
+  public run(it: IterableIterator<Value>, context: Context): Promise<Result> {
+    return new Promise((resolve, reject) => {
+      const itValue = it.next()
+      try {
+        if (itValue.done) {
+          resolve({ status: 'finished', context, value: itValue.value })
+        } else {
+          resolve({
+            status: 'suspended-non-det',
+            it,
+            scheduler: this,
+            context,
+            value: itValue.value
+          } as Result)
+        }
+      } catch (e) {
+        resolve({ status: 'error' })
+      } finally {
+        context.runtime.isRunning = false
+      }
+    })
+  }
+}
+
 export class PreemptiveScheduler implements Scheduler {
   constructor(public steps: number) {}
 

--- a/src/stdlib/non-det.prelude.ts
+++ b/src/stdlib/non-det.prelude.ts
@@ -1,0 +1,15 @@
+export const nonDetPrelude = `
+    /* DISTINCT */
+    /* The distinct function checks whether the items in a list are unique. */
+    /* Taken from SICP JS section 4.3.2 */
+
+    function distinct(items) {
+        return is_null(items)
+            ? true
+            : is_null(tail(items))
+            ? true
+            : is_null(member(head(items), tail(items)))
+                ? distinct(tail(items))
+                : false;
+    }
+`

--- a/src/stdlib/non-det.prelude.ts
+++ b/src/stdlib/non-det.prelude.ts
@@ -12,4 +12,13 @@ export const nonDetPrelude = `
                 ? distinct(tail(items))
                 : false;
     }
+
+    function an_element_of(items) {
+        require(!is_null(items));
+        return amb(head(items), an_element_of(tail(items)));
+    }
+
+    function an_integer_between(low, high) {
+        return low > high ? amb() : amb(low, an_integer_between(low + 1, high));
+    }
 `

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,7 +161,11 @@ export interface Suspended {
   context: Context
 }
 
-export type Result = Suspended | Finished | Error
+export type SuspendedNonDet = Omit<Suspended, 'status'> & { status: 'suspended-non-det' } & {
+  value: Value
+}
+
+export type Result = Suspended | SuspendedNonDet | Finished | Error
 
 export interface Scheduler {
   run(it: IterableIterator<Value>, context: Context): Promise<Result>

--- a/src/utils/rttc.ts
+++ b/src/utils/rttc.ts
@@ -108,3 +108,7 @@ export const checkMemberAccess = (node: es.Node, obj: Value, prop: Value) => {
     return new TypeError(node, '', 'object or array', typeOf(obj))
   }
 }
+
+export const isIdentifier = (node: any): node is es.Identifier => {
+  return (node as es.Identifier).name !== undefined
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,25 @@
     jest-diff "^25.1.0"
     pretty-format "^25.1.0"
 
+"@types/lodash.assignin@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.assignin/-/lodash.assignin-4.2.6.tgz#fe94b7bbad78f97897a028e8f4e8945c03d84a6f"
+  integrity sha512-kO9C2Oq0X8yehLu0o689SwR+wy+m4IQZg2TxRBXNkmpd0WY/GYEV+tTqrWRu2jt69eDOaVMJxna6QnDQ/g1TSg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.clonedeep@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
+  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/node@^13.7.0":
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"
@@ -2247,7 +2266,7 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.14:
+lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
This PR introduces non-deterministic Source 3 to `js-slang`.

Non deterministic Source 3 is a version of Source 3 with a built-in search mechanism.
Programmers can specify sets of *values*, and *requirements* that the values must satisfy.
The program evaluator then automatically identifies the values that meet the requirements.

We have created a REPL for this language in `src/repl/repl-non-det.ts`.
Here is the workflow for using the REPL:

Note:  **Any Source 3 program that does not use while loops, for loops or arrays is a valid non deterministic Source 3 program.**

1. run `yarn build` (only needed the first time)
2. run `node dist/repl/repl-non-det.ts`
3. type `.editor` to enter "editor" mode in the REPL. This allows input to be entered over multiple lines.
4. enter a program into the REPL. 
5. press CTRL + D
6. The REPL will return the first value that satisfied the requirements in your program.
7. If you want to see the next value that satisfied the requirements given in your program, enter `try again`. Note that `try again` is just a REPL command and not part of the language syntax.
8. If you want to evaluate a new program, repeat from Step 3.

#### How to specify possible values and requirements for those values?
The `amb` operator can be used to specify a set of values.
The expression `amb(e1, e2, e3, ...)` returns one of the values `e1`, `e2`, `e3,` , ...
If the program evaluator fails the requirements given after this expression, it will backtrack and
choose another value from the values `e1`, `e2`, `e3`, ...

Use the `require` operator to specify a requirement.
The operator accepts a single boolean expression. 
Example: `require(f > 3);` represents the requirement that the variable f should be greater than 3.


<br /> In the example below, we list all values of f larger than 3 <br />
```js
> const f = amb(1, 2, 3, 4, 5, 6); require(f > 3); f; 
4
> try again
5
> try again
6
> try again
undefined
```
You may read about non-deterministic programming in SICP [Chapter 4.3](https://sicp.comp.nus.edu.sg/chapters/85)


## Implementation
The interpreter is used for evaluation, in `interpreter-non-det.ts`. A general idea behind the modifications to the original interpreter is to avoid yielding any intermediate values of the program. Consequently, we are able to yield only final values of the program by using a custom scheduler, `NonDetScheduler`.

The following are the specific ideas harnessed in the evaluation of different expression types: <br />
- __variable declaration__: the right hand expression is evaluated. This returns a generator of possible values and we perform the variable declaration for each value.
- __binary / unary expressions__: we first evaluate the argument expressions of the application. This gives us generators for the arguments, and we apply the operator to each possible set of arguments
- __sequences__: the evaluation of each sequence is run as loop which nests the evaluation of each subsequent statement => this allows each possible value of statement 1 to be yielded with each possible value of statement 2 and so on, thereby enabling the combinatorial behaviour of `amb`
- `amb`: each of the provided arguments are evaluated in the original context (via deep cloning and resetting to the clone). This serves as a mechanism to backtrack to the original program state and undo effects such as assignments in a particular _world_
- `require`:  a (arbitrary) value is yielded iff the predicate evaluates to `true`. Therefore, no value being yielded causes subsequent statements to not be evaluated and the parent statement to continue to its next possible value
- `cut`: the `cut` operator functions similarly to that in the Prolog programming language. If a statement in a sequence is a `cut` statement or one of the subsequent statement is, then the statement is not added back to the sequence. Therefore, only the statements after `cut` remain in the sequence and are evaluated again for further values (eg. on invoking _try-again_)
