### PR TITLE
Add user friendly REPL message

### DIFF
--- a/src/repl/repl-non-det.ts
+++ b/src/repl/repl-non-det.ts
@@ -6,10 +6,10 @@ import { CUT, TRY_AGAIN } from '../constants'
 import { inspect } from 'util'
 import Closure from '../interpreter/closure'
 
-const NO_MORE_VALUES_MESSAGE = 'This world is exhausted, create a new one with amb'
+const NO_MORE_VALUES_MESSAGE: string = 'There are no more values of: '
+let previousInput: string | undefined // stores the input which is then shown when there are no more values for the program
+let previousResult: Result // stores the result obtained when execution is suspended
 
-// stores the result obtained when execution is suspended
-let previousResult: Result
 function _handleResult(
   result: Result,
   context: Context,
@@ -26,13 +26,24 @@ function _handleResult(
   }
 }
 
+function _try_again_message(): string | undefined {
+  if (previousInput) {
+    const message: string = NO_MORE_VALUES_MESSAGE + previousInput
+    previousInput = undefined
+    
+    return message
+  } else {
+    return undefined
+  }
+}
+
 function _resume(
   toResume: SuspendedNonDet,
   context: Context,
   callback: (err: Error | null, result: any) => void
 ) {
   Promise.resolve(resume(toResume)).then((result: Result) => {
-    if (result.status === 'finished') result.value = NO_MORE_VALUES_MESSAGE
+    if (result.status === 'finished') result.value = _try_again_message()
     _handleResult(result, context, callback)
   })
 }
@@ -41,7 +52,7 @@ function _try_again(context: Context, callback: (err: Error | null, result: any)
   if (previousResult && previousResult.status === 'suspended-non-det') {
     _resume(previousResult, context, callback)
   } else {
-    callback(null, NO_MORE_VALUES_MESSAGE)
+    callback(null, _try_again_message())
   }
 }
 
@@ -54,6 +65,7 @@ function _run(
   if (cmd.trim() === TRY_AGAIN) {
     _try_again(context, callback)
   } else {
+    previousInput = cmd.trim()
     runInContext(cmd, context, options).then(result => {
       _handleResult(result, context, callback)
     })

--- a/src/repl/repl-non-det.ts
+++ b/src/repl/repl-non-det.ts
@@ -6,6 +6,8 @@ import { CUT, TRY_AGAIN } from '../constants'
 import { inspect } from 'util'
 import Closure from '../interpreter/closure'
 
+const NO_MORE_VALUES_MESSAGE = 'This world is exhausted, create a new one with amb'
+
 // stores the result obtained when execution is suspended
 let previousResult: Result
 function _handleResult(
@@ -30,6 +32,7 @@ function _resume(
   callback: (err: Error | null, result: any) => void
 ) {
   Promise.resolve(resume(toResume)).then((result: Result) => {
+    if (result.status === 'finished') result.value = NO_MORE_VALUES_MESSAGE
     _handleResult(result, context, callback)
   })
 }
@@ -38,7 +41,7 @@ function _try_again(context: Context, callback: (err: Error | null, result: any)
   if (previousResult && previousResult.status === 'suspended-non-det') {
     _resume(previousResult, context, callback)
   } else {
-    callback(null, undefined)
+    callback(null, NO_MORE_VALUES_MESSAGE)
   }
 }
 


### PR DESCRIPTION
This PR changes the message shown when `try again` is invoked after a program has been entered,  in order to increase user friendliness.

The change is from `undefined` to `There are no more values of: <program entered by user>` 